### PR TITLE
Enable inline editing of statute hierarchy

### DIFF
--- a/routes/hierarchy_routes.py
+++ b/routes/hierarchy_routes.py
@@ -708,3 +708,92 @@ def delete_subsection(subsection_id):
         current_app.logger.error(f"Error deleting subsection: {str(e)}")
         flash("An error occurred while deleting the subsection.", "danger")
         return redirect(url_for('statute.list_statutes'))
+
+
+@hierarchy_bp.route('/hierarchy/component', methods=['POST'])
+@login_required
+def component_api():
+    """Generic API endpoint to manage hierarchy components."""
+    try:
+        data = request.get_json() or {}
+        action = data.get('action')
+        comp_type = data.get('type')
+
+        component_map = {
+            'part': (Part, 'statute_id'),
+            'chapter': (Chapter, 'part_id'),
+            'set': (Set, 'chapter_id'),
+            'section': (Section, 'set_id'),
+            'subsection': (Subsection, 'section_id')
+        }
+
+        if comp_type not in component_map:
+            return jsonify({'success': False, 'message': 'Invalid component type'}), 400
+
+        model, parent_field = component_map[comp_type]
+
+        if action == 'add':
+            parent_id = data.get('parent_id')
+            fields = {
+                'name': data.get('name'),
+                'order_no': get_next_order_no(parent_id, model, parent_field),
+                'created_at': datetime.now(pytz.UTC),
+                'updated_at': datetime.now(pytz.UTC)
+            }
+            number_field = f"{comp_type}_no"
+            if number_field in model.__table__.columns and data.get('number') is not None:
+                fields[number_field] = data.get('number')
+            if comp_type == 'subsection':
+                fields['content'] = data.get('content', '')
+
+            fields[parent_field] = parent_id
+            obj = model(**fields)
+            success, message = save_with_transaction(obj)
+            if success:
+                return jsonify({'success': True, 'component': obj.to_dict()})
+            return jsonify({'success': False, 'message': message}), 400
+
+        elif action == 'edit':
+            comp_id = data.get('id')
+            obj = db.session.query(model).filter(model.id == comp_id).first()
+            if not obj:
+                return jsonify({'success': False, 'message': 'Component not found'}), 404
+            if data.get('name') is not None:
+                obj.name = data.get('name')
+            number_field = f"{comp_type}_no"
+            if number_field in model.__table__.columns and data.get('number') is not None:
+                setattr(obj, number_field, data.get('number'))
+            if comp_type == 'subsection' and data.get('content') is not None:
+                obj.content = data.get('content')
+            obj.updated_at = datetime.now(pytz.UTC)
+            success, message = save_with_transaction(obj)
+            if success:
+                return jsonify({'success': True, 'component': obj.to_dict()})
+            return jsonify({'success': False, 'message': message}), 400
+
+        elif action == 'delete':
+            comp_id = data.get('id')
+            obj = db.session.query(model).filter(model.id == comp_id).first()
+            if not obj:
+                return jsonify({'success': False, 'message': 'Component not found'}), 404
+            db.session.delete(obj)
+            db.session.commit()
+            return jsonify({'success': True})
+
+        elif action == 'reorder':
+            parent_id = data.get('parent_id')
+            order = data.get('order', [])
+            for idx, comp_id in enumerate(order, start=1):
+                db.session.query(model).filter(
+                    model.id == comp_id,
+                    getattr(model, parent_field) == parent_id
+                ).update({'order_no': idx})
+            db.session.commit()
+            return jsonify({'success': True})
+
+        return jsonify({'success': False, 'message': 'Invalid action'}), 400
+
+    except Exception as e:
+        db.session.rollback()
+        current_app.logger.error(f"Component API error: {str(e)}")
+        return jsonify({'success': False, 'message': 'Server error'}), 500

--- a/static/js/hierarchy.js
+++ b/static/js/hierarchy.js
@@ -1,0 +1,105 @@
+// JavaScript for inline hierarchy management
+
+document.addEventListener('DOMContentLoaded', function() {
+    initComponentHandlers();
+    initSortableLists();
+});
+
+function initComponentHandlers() {
+    // Add
+    document.querySelectorAll('.component-add').forEach(btn => {
+        btn.addEventListener('click', async function(e) {
+            e.preventDefault();
+            const type = this.dataset.type;
+            const parentId = this.dataset.parentId;
+            const name = prompt(`Enter ${type} name:`);
+            if (name === null) return;
+            const number = prompt(`Enter ${type} number (optional):`);
+            let content = null;
+            if (type === 'subsection') {
+                content = prompt('Enter content:');
+                if (content === null) return;
+            }
+            const res = await fetch('/hierarchy/component', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ action: 'add', type, parent_id: parentId, name, number, content })
+            });
+            const data = await res.json();
+            if (data.success) {
+                location.reload();
+            } else {
+                alert(data.message || 'Error adding component');
+            }
+        });
+    });
+
+    // Edit
+    document.querySelectorAll('.component-edit').forEach(btn => {
+        btn.addEventListener('click', async function(e) {
+            e.preventDefault();
+            const type = this.dataset.type;
+            const id = this.dataset.id;
+            const name = prompt(`Edit ${type} name:`, this.dataset.name || '');
+            if (name === null) return;
+            const number = prompt(`Edit ${type} number (optional):`, this.dataset.number || '');
+            let content = null;
+            if (type === 'subsection') {
+                content = prompt('Edit content:', this.dataset.content || '');
+                if (content === null) return;
+            }
+            const res = await fetch('/hierarchy/component', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ action: 'edit', type, id, name, number, content })
+            });
+            const data = await res.json();
+            if (data.success) {
+                location.reload();
+            } else {
+                alert(data.message || 'Error updating component');
+            }
+        });
+    });
+
+    // Delete
+    document.querySelectorAll('.component-delete').forEach(btn => {
+        btn.addEventListener('click', async function(e) {
+            e.preventDefault();
+            if (!confirm('Are you sure you want to delete this item?')) return;
+            const type = this.dataset.type;
+            const id = this.dataset.id;
+            const res = await fetch('/hierarchy/component', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ action: 'delete', type, id })
+            });
+            const data = await res.json();
+            if (data.success) {
+                location.reload();
+            } else {
+                alert(data.message || 'Error deleting component');
+            }
+        });
+    });
+}
+
+function initSortableLists() {
+    document.querySelectorAll('.sortable-list').forEach(list => {
+        new Sortable(list, {
+            group: list.dataset.groupName,
+            handle: '.tree-item',
+            animation: 150,
+            onEnd: async function() {
+                const type = list.dataset.level;
+                const parentId = list.dataset.parentId;
+                const order = Array.from(list.children).map(li => li.dataset.id);
+                await fetch('/hierarchy/component', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ action: 'reorder', type, parent_id: parentId, order })
+                });
+            }
+        });
+    });
+}

--- a/templates/statute/view.html
+++ b/templates/statute/view.html
@@ -19,7 +19,7 @@
         <div class="action-buttons">
             <a href="{{ url_for('statute.book_view', statute_id=statute.id) }}" class="btn btn-primary">📖 Book View</a>
             <a href="{{ url_for('statute.edit_statute', statute_id=statute.id) }}" class="btn btn-secondary">Edit Statute</a>
-            <a href="{{ url_for('hierarchy.add_part', statute_id=statute.id) }}" class="btn btn-primary">Add Part</a>
+            <a href="#" class="btn btn-primary component-add" data-type="part" data-parent-id="{{ statute.id }}">Add Part</a>
             <a href="{{ url_for('schedule.add_sch_part', statute_id=statute.id) }}" class="btn btn-primary">Add Schedule</a>
             <a href="{{ url_for('annotation.add_annotation', statute_id=statute.id)  }}" class="btn btn-outline">Add Annotation</a>
             <a href="{{ url_for('annotation.list_statute_annotations', statute_id=statute.id) }}" class="btn btn-secondary">View Annotations</a>
@@ -58,16 +58,15 @@
                             <span class="item-name">{{ part.name }}</span>
                         </div>
                         <div class="tree-actions">
-                            <a href="{{ url_for('hierarchy.add_chapter', part_id=part.id) }}" class="btn-small btn-add" title="Add Chapter">
+                            <a href="#" class="btn-small btn-add component-add" data-type="chapter" data-parent-id="{{ part.id }}" title="Add Chapter">
                                 <i class="action-icon add-icon">+</i> Add Chapter
                             </a>
-                            <a href="{{ url_for('hierarchy.edit_part', part_id=part.id) }}" class="btn-small btn-secondary" title="Edit Part">
+                            <a href="#" class="btn-small btn-secondary component-edit" data-type="part" data-id="{{ part.id }}" data-name="{{ part.name|e }}" data-number="{{ part.part_no|e }}" title="Edit Part">
                                 <i class="action-icon edit-icon">✎</i> Edit
                             </a>
-                            <a href="#" class="btn-small btn-delete" title="Delete Part" onclick="document.getElementById('delete-part-form-{{ part.id }}').submit(); return false;">
+                            <a href="#" class="btn-small btn-delete component-delete" data-type="part" data-id="{{ part.id }}" title="Delete Part">
                                 <i class="action-icon delete-icon">×</i> Delete
                             </a>
-                            <form id="delete-part-form-{{ part.id }}" action="{{ url_for('hierarchy.delete_part', part_id=part.id) }}" method="post" class="inline-form" onsubmit="return confirm('Are you sure you want to delete this part and all its components?');" style="display: none;"></form>
                         </div>
                     </div>
                     
@@ -86,16 +85,15 @@
                                     <span class="item-name">{{ chapter.name }}</span>
                                 </div>
                                 <div class="tree-actions">
-                                    <a href="{{ url_for('hierarchy.add_set', chapter_id=chapter.id) }}" class="btn-small btn-add" title="Add Set">
+                                    <a href="#" class="btn-small btn-add component-add" data-type="set" data-parent-id="{{ chapter.id }}" title="Add Set">
                                         <i class="action-icon add-icon">+</i> Add Set
                                     </a>
-                                    <a href="{{ url_for('hierarchy.edit_chapter', chapter_id=chapter.id) }}" class="btn-small btn-secondary" title="Edit Chapter">
+                                    <a href="#" class="btn-small btn-secondary component-edit" data-type="chapter" data-id="{{ chapter.id }}" data-name="{{ chapter.name|e }}" data-number="{{ chapter.chapter_no|e }}" title="Edit Chapter">
                                         <i class="action-icon edit-icon">✎</i> Edit
                                     </a>
-                                    <a href="#" class="btn-small btn-delete" title="Delete Chapter" onclick="document.getElementById('delete-chapter-form-{{ chapter.id }}').submit(); return false;">
+                                    <a href="#" class="btn-small btn-delete component-delete" data-type="chapter" data-id="{{ chapter.id }}" title="Delete Chapter">
                                         <i class="action-icon delete-icon">×</i> Delete
                                     </a>
-                                    <form id="delete-chapter-form-{{ chapter.id }}" action="{{ url_for('hierarchy.delete_chapter', chapter_id=chapter.id) }}" method="post" class="inline-form" onsubmit="return confirm('Are you sure you want to delete this chapter and all its components?');" style="display: none;"></form>
                                 </div>
                             </div>
                             
@@ -114,16 +112,15 @@
                                             <span class="item-name">{{ set.name }}</span>
                                         </div>
                                         <div class="tree-actions">
-                                            <a href="{{ url_for('hierarchy.add_section', set_id=set.id) }}" class="btn-small btn-add" title="Add Section">
+                                            <a href="#" class="btn-small btn-add component-add" data-type="section" data-parent-id="{{ set.id }}" title="Add Section">
                                                 <i class="action-icon add-icon">+</i> Add Section
                                             </a>
-                                            <a href="{{ url_for('hierarchy.edit_set', set_id=set.id) }}" class="btn-small btn-secondary" title="Edit Set">
+                                            <a href="#" class="btn-small btn-secondary component-edit" data-type="set" data-id="{{ set.id }}" data-name="{{ set.name|e }}" data-number="{{ set.set_no|e }}" title="Edit Set">
                                                 <i class="action-icon edit-icon">✎</i> Edit
                                             </a>
-                                            <a href="#" class="btn-small btn-delete" title="Delete Set" onclick="document.getElementById('delete-set-form-{{ set.id }}').submit(); return false;">
+                                            <a href="#" class="btn-small btn-delete component-delete" data-type="set" data-id="{{ set.id }}" title="Delete Set">
                                                 <i class="action-icon delete-icon">×</i> Delete
                                             </a>
-                                            <form id="delete-set-form-{{ set.id }}" action="{{ url_for('hierarchy.delete_set', set_id=set.id) }}" method="post" class="inline-form" onsubmit="return confirm('Are you sure you want to delete this set and all its components?');" style="display: none;"></form>
                                         </div>
                                     </div>
                                     
@@ -142,16 +139,15 @@
                                                     <span class="item-name">{{ section.name }}</span>
                                                 </div>
                                                 <div class="tree-actions">
-                                                    <a href="{{ url_for('hierarchy.add_subsection', section_id=section.id) }}" class="btn-small btn-add" title="Add Subsection">
+                                                    <a href="#" class="btn-small btn-add component-add" data-type="subsection" data-parent-id="{{ section.id }}" title="Add Subsection">
                                                         <i class="action-icon add-icon">+</i> Add Subsection
                                                     </a>
-                                                    <a href="{{ url_for('hierarchy.edit_section', section_id=section.id) }}" class="btn-small btn-secondary" title="Edit Section">
+                                                    <a href="#" class="btn-small btn-secondary component-edit" data-type="section" data-id="{{ section.id }}" data-name="{{ section.name|e }}" data-number="{{ section.section_no|e }}" title="Edit Section">
                                                         <i class="action-icon edit-icon">✎</i> Edit
                                                     </a>
-                                                    <a href="#" class="btn-small btn-delete" title="Delete Section" onclick="document.getElementById('delete-section-form-{{ section.id }}').submit(); return false;">
+                                                    <a href="#" class="btn-small btn-delete component-delete" data-type="section" data-id="{{ section.id }}" title="Delete Section">
                                                         <i class="action-icon delete-icon">×</i> Delete
                                                     </a>
-                                                    <form id="delete-section-form-{{ section.id }}" action="{{ url_for('hierarchy.delete_section', section_id=section.id) }}" method="post" class="inline-form" onsubmit="return confirm('Are you sure you want to delete this section and all its subsections?');" style="display: none;"></form>
                                                 </div>
                                             </div>
                                             
@@ -167,13 +163,12 @@
                                                             <span class="item-name">{{ subsection.name if subsection.name else "" }}</span>
                                                         </div>
                                                         <div class="tree-actions">
-                                                            <a href="{{ url_for('hierarchy.edit_subsection', subsection_id=subsection.id) }}" class="btn-small btn-secondary" title="Edit Subsection">
+                                                            <a href="#" class="btn-small btn-secondary component-edit" data-type="subsection" data-id="{{ subsection.id }}" data-name="{{ subsection.name|e }}" data-number="{{ subsection.subsection_no|e }}" data-content="{{ subsection.content|e }}" title="Edit Subsection">
                                                                 <i class="action-icon edit-icon">✎</i> Edit
                                                             </a>
-                                                            <a href="#" class="btn-small btn-delete" title="Delete Subsection" onclick="document.getElementById('delete-subsection-form-{{ subsection.id }}').submit(); return false;">
+                                                            <a href="#" class="btn-small btn-delete component-delete" data-type="subsection" data-id="{{ subsection.id }}" title="Delete Subsection">
                                                                 <i class="action-icon delete-icon">×</i> Delete
                                                             </a>
-                                                            <form id="delete-subsection-form-{{ subsection.id }}" action="{{ url_for('hierarchy.delete_subsection', subsection_id=subsection.id) }}" method="post" class="inline-form" onsubmit="return confirm('Are you sure you want to delete this subsection?');" style="display: none;"></form>
                                                         </div>
                                                     </div>
                                                     <div class="subsection-content">
@@ -218,7 +213,7 @@
         {% else %}
         <div class="empty-state">
             <p>No parts have been added to this statute yet.</p>
-            <a href="{{ url_for('hierarchy.add_part', statute_id=statute.id) }}" class="btn btn-primary">Add First Part</a>
+            <a href="#" class="btn btn-primary component-add" data-type="part" data-parent-id="{{ statute.id }}">Add First Part</a>
         </div>
         {% endif %}
     </div>
@@ -426,6 +421,7 @@
 {% endblock %}
 
 {% block scripts %}
+<script src="{{ url_for('static', filename='js/hierarchy.js') }}"></script>
 <script>
     document.addEventListener('DOMContentLoaded', function() {
         // Initialize collapsible tree items


### PR DESCRIPTION
## Summary
- Add REST-like endpoint for adding, updating, deleting and reordering hierarchy items
- Replace separate hierarchy pages with inline controls on statute view
- Introduce client-side handlers for inline editing and drag-and-drop ordering

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68933c6cbda883259a1de13a83f4cd82